### PR TITLE
Form validation and to maintain form values

### DIFF
--- a/src/components/Checkout/AddressForm.js
+++ b/src/components/Checkout/AddressForm.js
@@ -3,20 +3,57 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import FormHelperText from '@mui/material/FormHelperText';
 import Checkbox from '@mui/material/Checkbox';
 import { InputLabel, MenuItem, Select } from '@mui/material';
 import COUNTRIES_STATES from '../../constants/countriesStates.json';
 
-export default function AddressForm() {
+export default function AddressForm({onChange, formValues, errors}) {
 
-  const [countrySelected, setCountrySelected] = React.useState('')
+  const zip = formValues.zip || ''
 
+  const name = formValues.name || ''
+
+  const lastName = formValues.lastName || ''
+
+  const addressFirst = formValues.addressFirst || ''
+
+  const city = formValues.city || ''
+
+  const countrySelected = formValues.country || ""
+
+  const provinceSelected = formValues.province || ""
+  
   const countrySelectedObj = COUNTRIES_STATES.countries.find((countryObj)=>(countryObj.country === countrySelected))
 
-  const countryStates = countrySelectedObj?.states || []; 
+  const countryStates = countrySelectedObj?.states || [];
+
+  const handleChangeZip = (event) => {
+    onChange('zip', event.target.value)
+  }
+
+  const handleChangeName = (event) => {
+    onChange('name', event.target.value)
+  }
+
+  const handleChangeLastName = (event) => {
+    onChange('lastName', event.target.value)
+  }
+
+  const handleChangeAddressFirst = (event) => {
+    onChange('addressFirst', event.target.value)
+  }
+
+  const handleChangeCity = (event) => {
+    onChange('city', event.target.value)
+  }
 
   const handleCountryChange = (event) => {
-    setCountrySelected(event.target.value)
+    onChange('country', event.target.value)
+  }
+
+  const handleProvinceChange = (event) => {
+    onChange('province', event.target.value)
   }
 
   return (
@@ -24,7 +61,7 @@ export default function AddressForm() {
       <Typography variant="h6" gutterBottom>
         Shipping address
       </Typography>
-      <Grid container spacing={3}>
+      <Grid container spacing={3} component="form">
         <Grid item xs={12} sm={6}>
           <TextField
             required
@@ -34,6 +71,10 @@ export default function AddressForm() {
             fullWidth
             autoComplete="given-name"
             variant="standard"
+            value={name}
+            onChange={handleChangeName}
+            error={errors.name ? true : false}
+            helperText={errors?.name}
           />
         </Grid>
         <Grid item xs={12} sm={6}>
@@ -45,6 +86,10 @@ export default function AddressForm() {
             fullWidth
             autoComplete="family-name"
             variant="standard"
+            value={lastName}
+            onChange={handleChangeLastName}
+            error={errors.lastName ? true : false}
+            helperText={errors?.lastName}
           />
         </Grid>
         <Grid item xs={12}>
@@ -56,6 +101,10 @@ export default function AddressForm() {
             fullWidth
             autoComplete="shipping address-line1"
             variant="standard"
+            value={addressFirst}
+            onChange={handleChangeAddressFirst}
+            error={errors.addressFirst ? true : false}
+            helperText={errors?.addressFirst}
           />
         </Grid>
         <Grid item xs={12}>
@@ -77,6 +126,10 @@ export default function AddressForm() {
             fullWidth
             autoComplete="shipping postal-code"
             variant="standard"
+            value={zip}
+            onChange={handleChangeZip}
+            error={errors?.zip}
+            helperText={errors?.zip}
           />
         </Grid>
         <Grid item xs={12} sm={6}>
@@ -88,6 +141,10 @@ export default function AddressForm() {
             fullWidth
             autoComplete="shipping address-level2"
             variant="standard"
+            value={city}
+            onChange={handleChangeCity}
+            error={errors.city ? true : false}
+            helperText={errors?.city}
           />
         </Grid>
         <Grid item xs={12} sm={6}>
@@ -104,6 +161,7 @@ export default function AddressForm() {
               <MenuItem key={countriesObj.country} value={countriesObj.country}>{countriesObj.country}</MenuItem>
             ))}
           </Select>
+          <FormHelperText>Required field</FormHelperText>
         </Grid>
         <Grid item xs={12} sm={6}>
           <InputLabel id="state-select-label">State/Province/Region *</InputLabel>
@@ -112,11 +170,14 @@ export default function AddressForm() {
             labelId="state-select-label"
             fullWidth
             variant='standard'
+            value={provinceSelected}
+            onChange={handleProvinceChange}
             >
             {countryStates.map((state) => (
               <MenuItem key={state} value={state}>{state}</MenuItem>
             ))}
             </Select>
+            <FormHelperText>Required field</FormHelperText>
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel

--- a/src/components/Checkout/AddressForm.js
+++ b/src/components/Checkout/AddressForm.js
@@ -11,21 +11,13 @@ import COUNTRIES_STATES from '../../constants/countriesStates.json';
 export default function AddressForm({onChange, formValues, errors}) {
 
   const zip = formValues.zip || ''
-
   const name = formValues.name || ''
-
   const lastName = formValues.lastName || ''
-
   const addressFirst = formValues.addressFirst || ''
-
   const city = formValues.city || ''
-
   const countrySelected = formValues.country || ""
-
   const provinceSelected = formValues.province || ""
-  
   const countrySelectedObj = COUNTRIES_STATES.countries.find((countryObj)=>(countryObj.country === countrySelected))
-
   const countryStates = countrySelectedObj?.states || [];
 
   const handleChangeZip = (event) => {

--- a/src/components/Checkout/AddressForm.js
+++ b/src/components/Checkout/AddressForm.js
@@ -14,6 +14,7 @@ export default function AddressForm({onChange, formValues, errors}) {
   const name = formValues.name || ''
   const lastName = formValues.lastName || ''
   const addressFirst = formValues.addressFirst || ''
+  const addressSecond = formValues.addressSecond || ''
   const city = formValues.city || ''
   const countrySelected = formValues.country || ""
   const provinceSelected = formValues.province || ""
@@ -34,6 +35,10 @@ export default function AddressForm({onChange, formValues, errors}) {
 
   const handleChangeAddressFirst = (event) => {
     onChange('addressFirst', event.target.value)
+  }
+  
+  const handleChangeAddressSecond = (event) => {
+    onChange('addressSecond', event.target.value)
   }
 
   const handleChangeCity = (event) => {
@@ -107,6 +112,8 @@ export default function AddressForm({onChange, formValues, errors}) {
             fullWidth
             autoComplete="shipping address-line2"
             variant="standard"
+            value={addressSecond}
+            onChange={handleChangeAddressSecond}
           />
         </Grid>
         <Grid item xs={12} sm={6}>

--- a/src/components/Checkout/AddressForm.js
+++ b/src/components/Checkout/AddressForm.js
@@ -70,7 +70,7 @@ export default function AddressForm({onChange, formValues, errors}) {
             variant="standard"
             value={name}
             onChange={handleChangeName}
-            error={errors.name ? true : false}
+            error={Boolean(errors.name)}
             helperText={errors?.name}
           />
         </Grid>
@@ -85,7 +85,7 @@ export default function AddressForm({onChange, formValues, errors}) {
             variant="standard"
             value={lastName}
             onChange={handleChangeLastName}
-            error={errors.lastName ? true : false}
+            error={Boolean(errors.lastName)}
             helperText={errors?.lastName}
           />
         </Grid>
@@ -100,7 +100,7 @@ export default function AddressForm({onChange, formValues, errors}) {
             variant="standard"
             value={addressFirst}
             onChange={handleChangeAddressFirst}
-            error={errors.addressFirst ? true : false}
+            error={Boolean(errors.addressFirst)}
             helperText={errors?.addressFirst}
           />
         </Grid>
@@ -127,7 +127,7 @@ export default function AddressForm({onChange, formValues, errors}) {
             variant="standard"
             value={zip}
             onChange={handleChangeZip}
-            error={errors?.zip}
+            error={Boolean(errors.zip)}
             helperText={errors?.zip}
           />
         </Grid>
@@ -142,7 +142,7 @@ export default function AddressForm({onChange, formValues, errors}) {
             variant="standard"
             value={city}
             onChange={handleChangeCity}
-            error={errors.city ? true : false}
+            error={Boolean(errors.city)}
             helperText={errors?.city}
           />
         </Grid>

--- a/src/components/Checkout/AddressForm.js
+++ b/src/components/Checkout/AddressForm.js
@@ -16,8 +16,8 @@ export default function AddressForm({onChange, formValues, errors}) {
   const addressFirst = formValues.addressFirst || ''
   const addressSecond = formValues.addressSecond || ''
   const city = formValues.city || ''
-  const countrySelected = formValues.country || ""
-  const provinceSelected = formValues.province || ""
+  const countrySelected = formValues.country || ''
+  const provinceSelected = formValues.province || ''
   const countrySelectedObj = COUNTRIES_STATES.countries.find((countryObj)=>(countryObj.country === countrySelected))
   const countryStates = countrySelectedObj?.states || [];
 

--- a/src/components/Checkout/Checkout.js
+++ b/src/components/Checkout/Checkout.js
@@ -23,7 +23,7 @@ function getStepContent(step, onChange, formValues, errors) {
     case 1:
       return <PaymentForm onChange={onChange} formValues={formValues} errors={errors}/>;
     case 2:
-      return <Review />;
+      return <Review formValues={formValues}/>;
     default:
       throw new Error('Unknown step');
   }

--- a/src/components/Checkout/Checkout.js
+++ b/src/components/Checkout/Checkout.js
@@ -21,7 +21,7 @@ function getStepContent(step, onChange, formValues, errors) {
     case 0:
       return <AddressForm onChange={onChange} formValues={formValues} errors={errors}/>;
     case 1:
-      return <PaymentForm />;
+      return <PaymentForm onChange={onChange} formValues={formValues} errors={errors}/>;
     case 2:
       return <Review />;
     default:
@@ -55,6 +55,20 @@ const getIsFormValid = (formValues, errors, step) => {
       return false
     }
   }
+  if(step===1){
+    if(errors.cardName || !formValues.cardName){
+      return false
+    }
+    if(errors.cardNumber || !formValues.cardNumber){
+      return false
+    }
+    if(errors.expDate || !formValues.expDate){
+      return false
+    }
+    if(!formValues.ccv){
+      return false
+    }
+  }
     return true
 }
 
@@ -62,9 +76,6 @@ const getFormErrors = (formValues) => {
   const errors = {}
   if(formValues.name === ''){
     errors.name = 'Required field' 
-  }
-  if(formValues.lastName === ''){
-    errors.lastName = 'Required field' 
   }
   if(formValues.lastName === ''){
     errors.lastName = 'Required field' 
@@ -77,6 +88,18 @@ const getFormErrors = (formValues) => {
   }
   if(formValues.city === ''){
     errors.city = 'Required field' 
+  }
+  if(formValues.cardName === ''){
+    errors.cardName = 'Required field' 
+  }
+  if(formValues.cardNumber === ''){
+    errors.cardNumber = 'Required field' 
+  }
+  if(formValues.expDate === ''){
+    errors.expDate = 'Required field' 
+  }
+  if(formValues.ccv === ''){
+    errors.ccv = 'Required field' 
   }
   return errors
 }

--- a/src/components/Checkout/Checkout.js
+++ b/src/components/Checkout/Checkout.js
@@ -16,10 +16,10 @@ import Review from './Review';
 
 const steps = ['Shipping address', 'Payment details', 'Review your order'];
 
-function getStepContent(step) {
+function getStepContent(step, onChange, formValues, errors) {
   switch (step) {
     case 0:
-      return <AddressForm />;
+      return <AddressForm onChange={onChange} formValues={formValues} errors={errors}/>;
     case 1:
       return <PaymentForm />;
     case 2:
@@ -31,9 +31,61 @@ function getStepContent(step) {
 
 const theme = createTheme();
 
+const getIsFormValid = (formValues, errors, step) => {
+  if(step===0){
+    if(errors.name || !formValues.name){
+      return false
+    }
+    if(errors.lastName || !formValues.lastName){
+      return false
+    }
+    if(errors.addressFirst || !formValues.addressFirst){
+      return false
+    }
+    if(errors.zip || !formValues.zip){
+      return false
+    }
+    if(errors.city || !formValues.city){
+      return false
+    }
+    if(!formValues.province){
+      return false
+    }
+    if(!formValues.country){
+      return false
+    }
+  }
+    return true
+}
+
+const getFormErrors = (formValues) => {
+  const errors = {}
+  if(formValues.name === ''){
+    errors.name = 'Required field' 
+  }
+  if(formValues.lastName === ''){
+    errors.lastName = 'Required field' 
+  }
+  if(formValues.lastName === ''){
+    errors.lastName = 'Required field' 
+  }
+  if(formValues.addressFirst === ''){
+    errors.addressFirst = 'Required field' 
+  }
+  if(formValues.zip === ''){
+    errors.zip = 'Required field' 
+  }
+  if(formValues.city === ''){
+    errors.city = 'Required field' 
+  }
+  return errors
+}
+
 export default function Checkout() {
   const [activeStep, setActiveStep] = React.useState(0);
 
+  const [formValues, setFormValues] = React.useState({});
+  
   const handleNext = () => {
     setActiveStep(activeStep + 1);
   };
@@ -41,6 +93,14 @@ export default function Checkout() {
   const handleBack = () => {
     setActiveStep(activeStep - 1);
   };
+
+  const onFormChange = (fieldName, fieldValue) => {
+    setFormValues({...formValues, [fieldName]:fieldValue})
+  }
+  
+  const errors = getFormErrors(formValues)
+
+  const isValid = getIsFormValid(formValues, errors, activeStep)
 
   return (
     <ThemeProvider theme={theme}>
@@ -81,7 +141,7 @@ export default function Checkout() {
               </React.Fragment>
             ) : (
               <React.Fragment>
-                {getStepContent(activeStep)}
+                {getStepContent(activeStep, onFormChange, formValues, errors)}
                 <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                   {activeStep !== 0 && (
                     <Button onClick={handleBack} sx={{ mt: 3, ml: 1 }}>
@@ -90,6 +150,7 @@ export default function Checkout() {
                   )}
 
                   <Button
+                    disabled={!isValid}
                     variant="contained"
                     onClick={handleNext}
                     sx={{ mt: 3, ml: 1 }}

--- a/src/components/Checkout/PaymentForm.js
+++ b/src/components/Checkout/PaymentForm.js
@@ -5,7 +5,29 @@ import TextField from '@mui/material/TextField';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 
-export default function PaymentForm() {
+export default function PaymentForm({onChange, formValues, errors}) {
+
+  const cardName = formValues.cardName || '';
+  const cardNumber = formValues.cardNumber || '';
+  const expDate = formValues.expDate || '';
+  const ccv = formValues.ccv || '';
+  
+  const handleCardName = (event) => {
+    onChange('cardName', event.target.value)
+  }
+
+  const handleCardNumber = (event) => {
+    onChange('cardNumber', event.target.value)
+  }
+
+  const handleExpDate = (event) => {
+    onChange('expDate', event.target.value)
+  }
+
+  const handleCcv = (event) => {
+    onChange('ccv', event.target.value)
+  }
+
   return (
     <React.Fragment>
       <Typography variant="h6" gutterBottom>
@@ -20,6 +42,10 @@ export default function PaymentForm() {
             fullWidth
             autoComplete="cc-name"
             variant="standard"
+            value={cardName}
+            onChange={handleCardName}
+            error={errors.cardName ? true : false}
+            helperText={errors?.cardName}
           />
         </Grid>
         <Grid item xs={12} md={6}>
@@ -30,6 +56,10 @@ export default function PaymentForm() {
             fullWidth
             autoComplete="cc-number"
             variant="standard"
+            value={cardNumber}
+            onChange={handleCardNumber}
+            error={errors.cardNumber ? true : false}
+            helperText={errors?.cardNumber}
           />
         </Grid>
         <Grid item xs={12} md={6}>
@@ -40,6 +70,10 @@ export default function PaymentForm() {
             fullWidth
             autoComplete="cc-exp"
             variant="standard"
+            value={expDate}
+            onChange={handleExpDate}
+            error={errors.expDate ? true : false}
+            helperText={errors?.expDate}
           />
         </Grid>
         <Grid item xs={12} md={6}>
@@ -51,6 +85,10 @@ export default function PaymentForm() {
             fullWidth
             autoComplete="cc-csc"
             variant="standard"
+            value={ccv}
+            onChange={handleCcv}
+            error={errors.ccv ? true : false}
+            helperText={errors?.ccv}
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/components/Checkout/PaymentForm.js
+++ b/src/components/Checkout/PaymentForm.js
@@ -44,7 +44,7 @@ export default function PaymentForm({onChange, formValues, errors}) {
             variant="standard"
             value={cardName}
             onChange={handleCardName}
-            error={errors.cardName ? true : false}
+            error={Boolean(errors.cardName)}
             helperText={errors?.cardName}
           />
         </Grid>
@@ -58,7 +58,7 @@ export default function PaymentForm({onChange, formValues, errors}) {
             variant="standard"
             value={cardNumber}
             onChange={handleCardNumber}
-            error={errors.cardNumber ? true : false}
+            error={Boolean(errors.cardNumber)}
             helperText={errors?.cardNumber}
           />
         </Grid>
@@ -72,7 +72,7 @@ export default function PaymentForm({onChange, formValues, errors}) {
             variant="standard"
             value={expDate}
             onChange={handleExpDate}
-            error={errors.expDate ? true : false}
+            error={Boolean(errors.expDate)}
             helperText={errors?.expDate}
           />
         </Grid>
@@ -87,7 +87,7 @@ export default function PaymentForm({onChange, formValues, errors}) {
             variant="standard"
             value={ccv}
             onChange={handleCcv}
-            error={errors.ccv ? true : false}
+            error={Boolean(errors.ccv)}
             helperText={errors?.ccv}
           />
         </Grid>

--- a/src/components/Checkout/Review.js
+++ b/src/components/Checkout/Review.js
@@ -64,7 +64,7 @@ export default function Review({ formValues }) {
           <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
             Shipping
           </Typography>
-          <Typography gutterBottom>John Smith</Typography>
+          <Typography gutterBottom>{formValues.name} {formValues.lastName}</Typography>
           <Typography gutterBottom>{formValues.addressFirst}, {formValues.addressSecond}</Typography>
         </Grid>
         <Grid item container direction="column" xs={12} sm={6}>

--- a/src/components/Checkout/Review.js
+++ b/src/components/Checkout/Review.js
@@ -29,15 +29,16 @@ const products = [
   { name: 'Shipping', desc: '', price: 'Free' },
 ];
 
-const addresses = ['1 MUI Drive', 'Reactville', 'Anytown', '99999', 'USA'];
-const payments = [
-  { name: 'Card type', detail: 'Visa' },
-  { name: 'Card holder', detail: 'Mr John Smith' },
-  { name: 'Card number', detail: 'xxxx-xxxx-xxxx-1234' },
-  { name: 'Expiry date', detail: '04/2024' },
-];
+export default function Review({ formValues }) {
 
-export default function Review() {
+  const maskedCardNumber = `xxxx-xxxx-xxxx-${formValues.cardNumber.slice(-4)}`
+  const payments = [
+    { name: 'Card type', detail: 'Visa' },
+    { name: 'Card holder', detail: formValues.cardName },
+    { name: 'Card number', detail: maskedCardNumber },
+    { name: 'Expiry date', detail: formValues.expDate },
+  ];
+
   return (
     <React.Fragment>
       <Typography variant="h6" gutterBottom>
@@ -64,7 +65,7 @@ export default function Review() {
             Shipping
           </Typography>
           <Typography gutterBottom>John Smith</Typography>
-          <Typography gutterBottom>{addresses.join(', ')}</Typography>
+          <Typography gutterBottom>{formValues.addressFirst}, {formValues.addressSecond}</Typography>
         </Grid>
         <Grid item container direction="column" xs={12} sm={6}>
           <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>

--- a/src/tests/Checkout.test.js
+++ b/src/tests/Checkout.test.js
@@ -16,7 +16,7 @@ const fillAdressForm = () => {
 
 const fillPaymentForm = () => {
   userEvent.type(screen.getByRole('textbox', { name: /name on card/i }), 'teste')
-  userEvent.type(screen.getByRole('textbox', { name: /card number/i }), 'teste')
+  userEvent.type(screen.getByRole('textbox', { name: /card number/i }), '123456789')
   userEvent.type(screen.getByRole('textbox', { name: /expiry date/i }), '1234')
   userEvent.type(screen.getByRole('textbox', { name: /cvv/i }), '1234')
 }
@@ -66,6 +66,17 @@ describe("Checkout", () => {
       userEvent.click(screen.getByRole('button', { name: 'Next' }));
 
       expect(screen.getByText('Order summary')).toBeInTheDocument();  
+    });
+
+    it("should render the card number masked ", () => {
+      render(<Checkout />);
+      fillAdressForm()
+      userEvent.click(screen.getByRole('button', { name: 'Next' }));
+      fillPaymentForm()
+      userEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+      expect(screen.getByText(/card number/i)).toBeInTheDocument();
+      expect(screen.getByText(/xxxx\-xxxx\-xxxx\-6789/i)).toBeInTheDocument();  
     });
   });
 

--- a/src/tests/Checkout.test.js
+++ b/src/tests/Checkout.test.js
@@ -2,6 +2,25 @@ import Checkout from "../components/Checkout";
 import { render, screen } from "@testing-library/react";
 import userEvent from '@testing-library/user-event';
 
+const fillAdressForm = () => {
+  userEvent.type(screen.getByRole('textbox', { name: /first name/i }), 'teste')
+  userEvent.type(screen.getByRole('textbox', { name: /last name/i }), 'teste')
+  userEvent.type(screen.getByRole('textbox', { name: /address line 1/i }), 'teste')
+  userEvent.type(screen.getByRole('textbox', { name: /zip \/ postal code/i }), '1234')
+  userEvent.type(screen.getByRole('textbox', { name: /city/i }), 'teste')
+  userEvent.click(screen.getByRole('button', { name: /country/i }));
+  userEvent.click(screen.getByRole('option', { name: /brazil/i }));
+  userEvent.click(screen.getByRole('button', { name: /state\/province\/region \*/i }));
+  userEvent.click(screen.getByRole('option', { name: /maranhao/i }));
+}
+
+const fillPaymentForm = () => {
+  userEvent.type(screen.getByRole('textbox', { name: /name on card/i }), 'teste')
+  userEvent.type(screen.getByRole('textbox', { name: /card number/i }), 'teste')
+  userEvent.type(screen.getByRole('textbox', { name: /expiry date/i }), '1234')
+  userEvent.type(screen.getByRole('textbox', { name: /cvv/i }), '1234')
+}
+
 describe("Checkout", () => {
   it("should render Checkout text ", () => {
     render(<Checkout />);
@@ -19,25 +38,34 @@ describe("Checkout", () => {
   });
 
   describe("When clicking in Next", () => {
-    beforeEach(()=>{
-      render(<Checkout />);
-      userEvent.type(screen.getByRole('textbox', { name: /first name/i }), 'teste')
-      userEvent.type(screen.getByRole('textbox', { name: /last name/i }), 'teste')
-      userEvent.type(screen.getByRole('textbox', { name: /address line 1/i }), 'teste')
-      userEvent.type(screen.getByRole('textbox', { name: /zip \/ postal code/i }), '1234')
-      userEvent.type(screen.getByRole('textbox', { name: /city/i }), 'teste')
-      userEvent.click(screen.getByRole('button', { name: /country/i }));
-      userEvent.click(screen.getByRole('option', { name: /brazil/i }));
-      userEvent.click(screen.getByRole('button', { name: /state\/province\/region \*/i }));
-      userEvent.click(screen.getByRole('option', { name: /maranhao/i }));
-      userEvent.click(screen.getByRole('button', { name: 'Next' }));
-    });
-
     it("should render payment method text ", () => {
-      expect(screen.getByText('Payment method')).toBeInTheDocument();  
-
+      render(<Checkout />);
+      fillAdressForm()
       userEvent.click(screen.getByRole('button', { name: 'Next' }));
-      expect(screen.getByText('Order summary')).toBeInTheDocument();
+
+      expect(screen.getByText('Payment method')).toBeInTheDocument();  
+    });
+  });
+
+  describe("When fill in the AdressForm and click in Next", () => {
+    it("should have a disabled Next button ", () => {
+      render(<Checkout />);
+      fillAdressForm()
+      userEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+    });
+  });
+
+  describe("When clicking in Next again", () => {
+    it("should render order summary text ", () => {
+      render(<Checkout />);
+      fillAdressForm()
+      userEvent.click(screen.getByRole('button', { name: 'Next' }));
+      fillPaymentForm()
+      userEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+      expect(screen.getByText('Order summary')).toBeInTheDocument();  
     });
   });
 

--- a/src/tests/Checkout.test.js
+++ b/src/tests/Checkout.test.js
@@ -13,18 +13,29 @@ describe("Checkout", () => {
     expect(screen.getAllByText('Shipping address')[1]).toBeInTheDocument();
   });
 
-  describe("When clicking in Next", () => {
-    it("should render payment method text ", () => {
-      render(<Checkout />);
-      userEvent.click(screen.getByRole('button', { name: 'Next' }));
-      expect(screen.getByText('Payment method')).toBeInTheDocument();
-    });
+  it("should have a disabled Next button", () => {
+    render(<Checkout />);
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
   });
 
-  describe("When clicking in Next twice", () => {
-    it("should render order summary text ", () => {
+  describe("When clicking in Next", () => {
+    beforeEach(()=>{
       render(<Checkout />);
+      userEvent.type(screen.getByRole('textbox', { name: /first name/i }), 'teste')
+      userEvent.type(screen.getByRole('textbox', { name: /last name/i }), 'teste')
+      userEvent.type(screen.getByRole('textbox', { name: /address line 1/i }), 'teste')
+      userEvent.type(screen.getByRole('textbox', { name: /zip \/ postal code/i }), '1234')
+      userEvent.type(screen.getByRole('textbox', { name: /city/i }), 'teste')
+      userEvent.click(screen.getByRole('button', { name: /country/i }));
+      userEvent.click(screen.getByRole('option', { name: /brazil/i }));
+      userEvent.click(screen.getByRole('button', { name: /state\/province\/region \*/i }));
+      userEvent.click(screen.getByRole('option', { name: /maranhao/i }));
       userEvent.click(screen.getByRole('button', { name: 'Next' }));
+    });
+
+    it("should render payment method text ", () => {
+      expect(screen.getByText('Payment method')).toBeInTheDocument();  
+
       userEvent.click(screen.getByRole('button', { name: 'Next' }));
       expect(screen.getByText('Order summary')).toBeInTheDocument();
     });

--- a/src/tests/Review.test.js
+++ b/src/tests/Review.test.js
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import Review from "../components/Checkout/Review";
+
+const formValues = {
+  "name": "Jeff",
+  "lastName": "Gomes",
+  "addressFirst": "First street",
+  "addressSecond": "second house",
+  "zip": "123",
+  "city": "teresina",
+  "country": "Brazil",
+  "province": "Piaui",
+  "cardName": "JRRG",
+  "cardNumber": "9876-5432-1236-6544",
+  "expDate": "12",
+  "ccv": "321"
+}
+
+beforeEach(() => {
+  render(<Review formValues={formValues}/>);
+});
+
+describe("Review", () => {
+  it("should render order summary text", () => {
+    expect(screen.getByText('Order summary')).toBeInTheDocument();
+  });
+
+  describe("when rendering the shipping and payment details", () => {
+    it("should render the shipping text", () => {
+      expect(screen.getAllByText('Shipping')[1]).toBeInTheDocument();
+    });
+
+    it("should render the correct shipping value Name", () => {
+      expect(screen.getByText(/jeff gomes/i)).toBeInTheDocument();
+    });
+
+    it("should render the correct shipping value Address", () => {
+      expect(screen.getByText(/First street, second house/i)).toBeInTheDocument();
+    });
+
+    it("should render the correct card name value", () => {
+      expect(screen.getByText(/JRRG/i)).toBeInTheDocument();
+    });
+
+    it("should render the correct card number value", () => {
+      expect(screen.getByText(/xxxx\-xxxx\-xxxx\-6544/i)).toBeInTheDocument();
+    });
+
+    it("should render the correct card expire date value", () => {
+      expect(screen.getByText(/12/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/tests/Review.test.js
+++ b/src/tests/Review.test.js
@@ -16,11 +16,11 @@ const formValues = {
   "ccv": "321"
 }
 
-beforeEach(() => {
-  render(<Review formValues={formValues}/>);
-});
-
 describe("Review", () => {
+  beforeEach(() => {
+    render(<Review formValues={formValues}/>);
+  });
+
   it("should render order summary text", () => {
     expect(screen.getByText('Order summary')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Task 3: Passagem dos campos para a tela de review

Ao chegar na tela de review todos os campos digitados precisam ser mostrados no formato de exemplo que hoje está estático.

- [x] Os botões `Next` precisam ser habilitados somente quando os campos definidios como `required` são preenchidos.
  - Mostrar a mensagem da validação é opcional para este desafio.
- [x] Os botões `Back` levam para a tela anterior, estas devem manter o formulário com os valores guardados.
- [x] Na tela de review o cartão de crédito deve ser mostrado no formato: xxxx-xxxx-xxxx-1234

- [x] Os testes de `Checkout.test.js` **devem** ser atualizados para incluir essas funcionalidades. Um teste somente da tela de Review demonstrando a impressão correta dos valores recebidos também é interessante.