### PR TITLE
Creating base components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
         "@mui/material": "^5.5.2",
+        "@styled-system/css": "^5.1.5",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -3304,6 +3305,11 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@styled-system/css": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
+      "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -18819,6 +18825,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@styled-system/css": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
+      "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A=="
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^5.5.2",
+    "@styled-system/css": "^5.1.5",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -7,13 +7,9 @@ import { Button, Text} from './components'
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
-      <div className='container'>
-        <Store />
-      </div>
-      <Button>Styled Button</Button>
-      <Text variant={'h1'}>Checkout -</Text>
-      <Text variant={'h2'}>Checkout -</Text>
-      <Text variant={'h3'}>Checkout</Text>
+          <div className='container'>
+            <Store />
+          </div>
     </ThemeProvider>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,11 @@
 import './App.css';
 import Store from './components/Store';
-import { ThemeProvider } from 'styled-components';
-import theme from './theme';
-import { Button, Text} from './components'
 
 const App = () => {
   return (
-    <ThemeProvider theme={theme}>
-          <div className='container'>
-            <Store />
-          </div>
-    </ThemeProvider>
+      <div className='container'>
+        <Store />
+      </div>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,8 @@
 import './App.css';
 import Store from './components/Store';
-import styled, { ThemeProvider } from 'styled-components';
+import { ThemeProvider } from 'styled-components';
 import theme from './theme';
-
-const Button = styled.button`
-  background-color: ${({ theme }) => theme.colors.darkGrey};
-  color: ${({ theme }) => theme.colors.lightGrey};
-  width: ${({ theme }) => theme.space[8]};
-  height: ${({ theme }) => theme.space[5]};
-  border-radius: ${({ theme }) => theme.radii[2]}
-`
+import { Button, Text} from './components'
 
 const App = () => {
   return (
@@ -18,6 +11,9 @@ const App = () => {
         <Store />
       </div>
       <Button>Styled Button</Button>
+      <Text variant={'h1'}>Checkout -</Text>
+      <Text variant={'h2'}>Checkout -</Text>
+      <Text variant={'h3'}>Checkout</Text>
     </ThemeProvider>
   );
 }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+const Button = styled.button`
+  background-color: ${({ theme }) => theme.colors.softBlue};
+  color: ${({ theme }) => theme.colors.backgroundColor};
+  width: ${({ theme }) => theme.space[8]};
+  height: ${({ theme }) => theme.space[5]};
+  border-radius: ${({ theme }) => theme.radii[2]};
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.lightGrey};
+    color: ${({ theme }) => theme.colors.softGrey};
+  };
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.darkBlue};
+    color: ${({ theme }) => theme.colors.lightBlue};
+  };
+`
+export default Button;

--- a/src/components/Checkout/Checkout.js
+++ b/src/components/Checkout/Checkout.js
@@ -7,12 +7,13 @@ import Paper from '@mui/material/Paper';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
-import Button from '@mui/material/Button';
+import { Button, Text } from '../../components'
 import Typography from '@mui/material/Typography';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
 import AddressForm from './AddressForm';
 import PaymentForm from './PaymentForm';
 import Review from './Review';
+import { ThemeProvider } from 'styled-components';
+import theme from '../../theme';
 
 const steps = ['Shipping address', 'Payment details', 'Review your order'];
 
@@ -28,8 +29,6 @@ function getStepContent(step, onChange, formValues, errors, cartItems) {
       throw new Error('Unknown step');
   }
 }
-
-const theme = createTheme();
 
 const getIsFormValid = (formValues, errors, step) => {
   if(step===0){
@@ -144,9 +143,9 @@ export default function Checkout({ cartItems }) {
       </AppBar>
       <Container component="main" maxWidth="sm" sx={{ mb: 4 }}>
         <Paper component="form" onSubmit={handleSubmit} variant="outlined" sx={{ my: { xs: 3, md: 6 }, p: { xs: 2, md: 3 } }}>
-          <Typography component="h1" variant="h4" align="center">
+          <Text variant="h2" align="center">
             Checkout
-          </Typography>
+          </Text>
           <Stepper activeStep={activeStep} sx={{ pt: 3, pb: 5 }}>
             {steps.map((label) => (
               <Step key={label}>
@@ -157,14 +156,14 @@ export default function Checkout({ cartItems }) {
           <React.Fragment>
             {activeStep === steps.length ? (
               <React.Fragment>
-                <Typography variant="h5" gutterBottom>
+                <Text variant="h3" gutterBottom>
                   Thank you for your order.
-                </Typography>
-                <Typography variant="subtitle1">
+                </Text>
+                <Text variant="h4">
                   Your order number is #2001539. We have emailed your order
                   confirmation, and will send you an update when your order has
                   shipped.
-                </Typography>
+                </Text>
               </React.Fragment>
             ) : (
               <React.Fragment>

--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from 'styled-components'
+
+const GlobalStyle = createGlobalStyle`
+body {
+  font-family: ${({ theme }) => theme.fonts};
+  background-color: ${({ theme }) => theme.colors.backgroundColor};
+}
+`
+export default GlobalStyle

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+const getError = ({ theme, error }) => {
+   if (error){
+     return theme.colors.errorRed;
+   }
+  return theme.colors.softGrey
+ }
+
+const Input = styled.input`
+  display: block;
+  width: 100%;
+  font: inherit;
+  border-top-style: none;
+  border-right-style: none;
+  border-left-style: none;
+  border-color: ${(props) => getError(props)};
+  margin-block-start: ${({ theme }) => theme.space[2]};
+  padding: ${({ theme }) => theme.space[0]} 0 ${({ theme }) => theme.space[0]};
+
+  &:focus {
+    outline: none;
+  };
+
+  option {
+    color: ${({ theme }) => theme.colors.darkGrey};
+  };
+`
+
+export default Input

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -14,9 +14,9 @@ const Input = styled.input`
   border-top-style: none;
   border-right-style: none;
   border-left-style: none;
-  border-color: ${(props) => getError(props)};
+  border-color: ${getError};
   margin-block-start: ${({ theme }) => theme.space[2]};
-  padding: ${({ theme }) => theme.space[0]} 0 ${({ theme }) => theme.space[0]};
+  padding: ${({ theme }) => `${theme.space[0]} 0 ${theme.space[0]}`};
 
   &:focus {
     outline: none;

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+const getFontSize = ({ variant, theme }) => {
+  const variantTypes = {
+    h1: theme.fontSizes[6],
+    h2: theme.fontSizes[5],
+    h3: theme.fontSizes[4],
+  }
+  return variantTypes[variant] || theme.fontSizes[3]
+}
+
+const getAlign = ({ align }) => {
+  const alignTypes = {
+    center: 'center',
+    left: 'left',
+    right: 'right',
+  }
+  return alignTypes[align] || 'left'
+}
+
+const Text = styled.text`
+  display: block;
+  font-size: ${(props) => getFontSize(props)};
+  text-align: ${(props) => getAlign(props)};
+  margin-block-end: ${({ theme }) => theme.space[3]};
+  line-height: ${({ theme }) => theme.space[4]};
+`
+
+export default Text

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -10,18 +10,13 @@ const getFontSize = ({ variant, theme }) => {
 }
 
 const getAlign = ({ align }) => {
-  const alignTypes = {
-    center: 'center',
-    left: 'left',
-    right: 'right',
-  }
-  return alignTypes[align] || 'left'
+  return align || 'left'
 }
 
 const Text = styled.text`
   display: block;
-  font-size: ${(props) => getFontSize(props)};
-  text-align: ${(props) => getAlign(props)};
+  font-size: ${getFontSize};
+  text-align: ${getAlign};
   margin-block-end: ${({ theme }) => theme.space[3]};
   line-height: ${({ theme }) => theme.space[4]};
 `

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,2 @@
+export { default as Button } from './Button'
+export { default as Text } from './Text'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,4 @@
 export { default as Button } from './Button'
 export { default as Text } from './Text'
+export { default as Input } from './Input'
+export { default as GlobalStyle } from './GlobalStyle'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,3 @@
 export { default as Button } from './Button'
 export { default as Text } from './Text'
 export { default as Input } from './Input'
-export { default as GlobalStyle } from './GlobalStyle'

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,11 +1,12 @@
 const colors = {
-  backgroundColor: '#cdf1e4',
+  backgroundColor: '#FBF8F1',
   darkGrey: '#333333',
   softGrey: '#a7a7a7',
   lightGrey: '#dddddd',
   softBlue: '#39AEA9',
   darkBlue: '#557B83',
   lightBlue: '#A2D5AB',
+  errorRed: '#FF5677',
 };
 
 const space = [

--- a/src/theme.js
+++ b/src/theme.js
@@ -2,7 +2,10 @@ const colors = {
   backgroundColor: '#cdf1e4',
   darkGrey: '#333333',
   softGrey: '#a7a7a7',
-  lightGrey: '#dddddd'
+  lightGrey: '#dddddd',
+  softBlue: '#39AEA9',
+  darkBlue: '#557B83',
+  lightBlue: '#A2D5AB',
 };
 
 const space = [
@@ -21,7 +24,7 @@ const space = [
   '24rem',
 ];
 
-const fonts = "'Montserrat', sans-serif";
+const fonts = '"Roboto","Helvetica","Arial",sans-serif';
 
 const fontSizes = [
   '0.25rem',


### PR DESCRIPTION
### This PR resolves the task 3 from this challenge:
https://gist.github.com/iagodahlem/5bed6e93ba9f08d25961f4504a4cff5c

### Task 3: Criando Componentes Base

Todos os componentes reescritos devem respeitar a mesma API de props do respectivo componente do MUI. _Não necessariamente todas os props, mas pelo menos as utilizadas no componente de `Checkout`_. Em caso de dúvidas sobre as props suportadas, consulte a documentação do componente em: https://mui.com/components.

Os componentes reescritos devem ser:

- [x] `TextField` para `Input`;
- [x] `Typography` para `Text`;
- [x] `Button`.

- [x] Eles devem ser criados numa pasta `src/components`, contendo um arquivo para cada componente, com um barrel file para poder importalos facilmente em outros lugares.

- [x] Sinta-se a vontade para alterar a estilização do componente ou tentar replicas os estilos do Material UI. Lembrando que a UI sempre deve ser concisa, e utilizar os valores do tema. Isso será importante para a última tarefa.

- [x] Para quem for replicar os estilos do MUI, não é necessário fazer a label flutuante, porém, é um desafio de estilização bem legal a ser encarado.

- [x] Altere tambem todos os estilos globais presentes no arquivo `index.css` para o `createGlobalStyle`, sempre usando os valores do tema.

#### 🏆 Bonus: `Grid` para `Flex`

- [ ] Como um desafio extra, crie um componente `Flex` e substituia todos os usos de `Grid` no `Checkout` para usar este componente.

- [ ] Escreva testes de snapshot para todos os componentes reescritos.
